### PR TITLE
payment types only show for current user

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -81,7 +81,7 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer = request.auth.user
+        customer = Customer.objects.get(user=request.auth.user)
 
         if customer is not None:
             payment_types = payment_types.filter(customer__id=customer.id)

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -81,10 +81,10 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        customer = request.auth.user
 
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+        if customer is not None:
+            payment_types = payment_types.filter(customer__id=customer.id)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})


### PR DESCRIPTION
Description of PR that completes issue here...
only payment types matching the current user will return 

## Changes

- changed the paymenttype view  list to only show the current users payment types

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET http://localhost:8000/paymenttypes


**Response**

HTTP/1.1 200 OK

```[
    {
        "id": 1,
        "url": "http://localhost:8000/paymenttypes/1",
        "merchant_name": "Visa",
        "account_number": "24ijio68948fj8439",
        "expiration_date": "2020-01-01",
        "create_date": "2019-11-11"
    }
]
```

## Testing

Description of how to test code...

- [ ] git fetch --all
- [ ] switch to branch 18-userpayments
- [ ] following steps are used with Postman
- [ ] login with credentials (username = steve) || (password = Admin8*) to get a token
- [ ] make a get request to http://localhost:8000/paymenttypes
- [ ] confirm the response is the same as the one above 


## Related Issues

- Fixes #18 